### PR TITLE
Add permission for lichess.org

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -12,6 +12,7 @@
     "default_icon": "logo.png"
   },
   "permissions": [
-    "activeTab"
+    "activeTab",
+    "https://lichess.org/*"
   ]
 }


### PR DESCRIPTION
This makes the extension compatible with Firefox.