### PR TITLE
Support games from chess.com/live + More error catching

### DIFF
--- a/importGameToLichess.js
+++ b/importGameToLichess.js
@@ -40,6 +40,9 @@
                         let lichessGameWindow = window.open(url);
                     } else alert("Could not import game");
 
+                }).catch((e) => {
+                    alert("Error getting response from lichess.org");
+                    throw new Error("Response error");
                 });
         }, 1);
     }, 1);

--- a/importGameToLichess.js
+++ b/importGameToLichess.js
@@ -5,7 +5,8 @@
         throw new Error("Wrong website");
     }
 //url on game check
-    if (!window.location.href.includes("chess.com/game/live")) {
+    if (!window.location.href.includes("chess.com/game/live") &&
+        !window.location.href.includes("chess.com/live#g=")) {
         alert("You are not on viewing a game! Press me when you are viewing the game you'd like to analyze! (when url contains chess.com/game/live)")
         throw new Error("Not on game");
     }
@@ -14,6 +15,14 @@
     let shareButton = document.getElementsByClassName("icon-font-chess share daily-game-footer-icon")[0];
     if (!shareButton) {
         shareButton = document.getElementsByClassName("icon-font-chess share live-game-buttons-button")[0];
+    }
+    if(!shareButton) {
+        // in case of chess.com/live#g=
+        shareButton = document.getElementsByClassName("icon-font-chess share game-buttons-button")[0];
+    }
+    if(!shareButton) {
+        alert("Valid sharable PGN not found");
+        throw new Error("No sharable PGN");
     }
     shareButton.click();
     setTimeout(() => {


### PR DESCRIPTION
1. Support for using the extension on live chess, i.e. URL such as ```https://www.chess.com/live#g=X```
2. Catch error in getting a response from lichess.org.
3. Catch error in finding a valid sharable PGN. 