### PR TITLE
Fix game not finished alert

### DIFF
--- a/injectHtmlButtonToPage.js
+++ b/injectHtmlButtonToPage.js
@@ -87,6 +87,11 @@ function importGame() {
     }
 
     if (!shareButton) {
+        // in other cases, try to find the button by aria-label "Share"
+        shareButton = document.querySelector('button[aria-label="Share"]');
+    }
+
+    if (!shareButton) {
         alert("The game is probably not finished. Try clicking me when the game is over.");
         throw new Error("No share button");
     }


### PR DESCRIPTION
The share button, which is required for the game to be able to be imported, sometimes has a different classname than expected, I tried to fix this by looking for the aria-label Share if finding the share button fails.

Fixes this issue:
https://github.com/WojtekTB/Chesscom-to-lichess-games/issues/16